### PR TITLE
feat: add dark theme switcher to app header

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -31,6 +31,18 @@
 	--map-border-width: 4px;
 }
 
+html[data-theme="dark"] {
+	--color-page-bg: #111827;
+	--color-card-bg: #1f2937;
+	--color-text: #f3f4f6;
+	--color-text-muted: #9ca3af;
+	--color-error: #f87171;
+	--color-footer: #9ca3af;
+
+	--shadow-card: 0 4px 6px rgb(0 0 0 / 0.35);
+	--shadow-header: 0 2px 8px rgb(0 0 0 / 0.4);
+}
+
 *,
 *::before,
 *::after {
@@ -67,17 +79,49 @@ img {
 	box-shadow: var(--shadow-header);
 	margin-bottom: 0.5rem;
 	padding: 1rem var(--space-page-inline);
-	text-align: center;
 
 	& .site-header__inner {
 		max-width: var(--max-content-width);
 		margin-inline: auto;
+		display: flex;
+		align-items: center;
+		justify-content: space-between;
+		gap: 1rem;
 	}
 
 	& .site-header__title {
 		margin: 0;
 		font-size: clamp(1.125rem, 2.5vw, 1.5rem);
 		font-weight: 700;
+	}
+}
+
+.theme-switcher {
+	flex-shrink: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2.25rem;
+	height: 2.25rem;
+	padding: 0;
+	font-size: 1.125rem;
+	line-height: 1;
+	background: rgb(255 255 255 / 0.2);
+	border: 2px solid rgb(255 255 255 / 0.5);
+	border-radius: 50%;
+	color: #fff;
+	cursor: pointer;
+	transition: background 0.2s ease, border-color 0.2s ease, transform 0.15s ease;
+
+	&:hover {
+		background: rgb(255 255 255 / 0.35);
+		border-color: #fff;
+		transform: scale(1.1);
+	}
+
+	&:focus-visible {
+		outline: 2px solid #fff;
+		outline-offset: 3px;
 	}
 }
 

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,9 +1,12 @@
 import "preact/jsx-runtime";
+import ThemeSwitcher from "@/islands/ThemeSwitcher.tsx";
+
 export function Header() {
 	return (
 		<header class="site-header">
 			<div class="site-header__inner">
 				<h1 class="site-header__title">🚌 ATM Milano Info Dashboard</h1>
+				<ThemeSwitcher />
 			</div>
 		</header>
 	);

--- a/islands/ThemeSwitcher.tsx
+++ b/islands/ThemeSwitcher.tsx
@@ -1,0 +1,48 @@
+import { useEffect, useState } from "preact/hooks";
+
+type Theme = "light" | "dark";
+
+const STORAGE_KEY = "atmmi-theme";
+
+function getInitialTheme(): Theme {
+	if (typeof localStorage !== "undefined") {
+		const stored = localStorage.getItem(STORAGE_KEY);
+		if (stored === "dark" || stored === "light") return stored;
+	}
+	if (typeof matchMedia !== "undefined" && matchMedia("(prefers-color-scheme: dark)").matches) {
+		return "dark";
+	}
+	return "light";
+}
+
+function applyTheme(theme: Theme) {
+	document.documentElement.dataset.theme = theme;
+}
+
+export default function ThemeSwitcher() {
+	const [theme, setTheme] = useState<Theme>("light");
+
+	useEffect(() => {
+		const initial = getInitialTheme();
+		setTheme(initial);
+		applyTheme(initial);
+	}, []);
+
+	function toggle() {
+		const next: Theme = theme === "light" ? "dark" : "light";
+		setTheme(next);
+		applyTheme(next);
+		localStorage.setItem(STORAGE_KEY, next);
+	}
+
+	return (
+		<button
+			class="theme-switcher"
+			onClick={toggle}
+			aria-label={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
+			title={theme === "light" ? "Switch to dark mode" : "Switch to light mode"}
+		>
+			{theme === "light" ? "🌙" : "☀️"}
+		</button>
+	);
+}

--- a/routes/_app.tsx
+++ b/routes/_app.tsx
@@ -17,6 +17,11 @@ export default define.page(function App({ Component }) {
 				<title>🚌 ATM Milano Info Dashboard</title>
 			</head>
 			<body>
+				<script
+					dangerouslySetInnerHTML={{
+						__html: `(function(){var s=localStorage.getItem('atmmi-theme');if(s==='dark'||s==='light'){document.documentElement.dataset.theme=s;}else if(matchMedia('(prefers-color-scheme: dark)').matches){document.documentElement.dataset.theme='dark';}})();`,
+					}}
+				/>
 				<Component />
 			</body>
 		</html>


### PR DESCRIPTION
## Summary

- Adds an interactive dark/light theme toggle button in the app header bar
- Implements dark mode CSS variables complementary to the existing light theme — metro line badge colours are intentionally unchanged
- Persists the user's choice in `localStorage` and respects `prefers-color-scheme` on first visit; an inline script sets `data-theme` before first paint to prevent flash of wrong theme

## Changes

| File | What changed |
|---|---|
| `islands/ThemeSwitcher.tsx` | New Fresh island — toggle button with moon/sun emoji, reads/writes `localStorage`, applies `html[data-theme]` |
| `components/Header.tsx` | Imports and renders `ThemeSwitcher` island |
| `assets/styles.css` | `html[data-theme="dark"]` block with dark palette; header inner layout changed to `flex`; `.theme-switcher` button styles added |
| `routes/_app.tsx` | Inline `<script>` before `<Component />` to apply saved theme before first paint |

## Dark theme palette

| Variable | Light | Dark |
|---|---|---|
| `--color-page-bg` | `#f4f4f4` | `#111827` |
| `--color-card-bg` | `#ffffff` | `#1f2937` |
| `--color-text` | `#111111` | `#f3f4f6` |
| `--color-text-muted` | `#6b7280` | `#9ca3af` |
| `--color-error` | `#b91c1c` | `#f87171` |
| Metro line colours | unchanged | unchanged |

## Test plan

- [ ] Toggle button visible in header (right side, circular)
- [ ] Click toggles between 🌙 (switch to dark) and ☀️ (switch to light)
- [ ] Dark mode applies correct background, card, and text colours
- [ ] Metro line badge colours are the same in both modes
- [ ] Preference survives a page reload (localStorage persistence)
- [ ] On a fresh visit with OS dark mode enabled, dark theme applies automatically
- [ ] No flash of wrong theme on page load

https://claude.ai/code/session_01P5GdBWjYAnDUyhHCwrzJAA

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5GdBWjYAnDUyhHCwrzJAA)_